### PR TITLE
Implement access tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ node_modules/
 .npm
 .eslintcache
 .vscode
+.idea

--- a/README.md
+++ b/README.md
@@ -28,12 +28,13 @@ const TwitchWebhook = require('twitch-webhook')
 const twitchWebhook = new TwitchWebhook({
     client_id: 'Your Twitch Client ID',
     callback: 'Your Callback URL',
-    secret: 'It\'s a secret', // default: false
-    lease_seconds: 259200,    // default: 864000 (maximum value)
+    access_token: 'Your access token', // default: null (ignored)
+    secret: 'It\'s a secret',          // default: false
+    lease_seconds: 259200,             // default: 864000 (maximum value)
     listen: {
-        port: 8080,           // default: 8443
-        host: '127.0.0.1',    // default: 0.0.0.0
-        autoStart: false      // default: true
+        port: 8080,                    // default: 8443
+        host: '127.0.0.1',             // default: 0.0.0.0
+        autoStart: false               // default: true
     }
 })
 

--- a/examples/main.js
+++ b/examples/main.js
@@ -1,15 +1,16 @@
 const TwitchWebhook = require('twitch-webhook')
 
 const twitchWebhook = new TwitchWebhook({
-    client_id: 'Your Twitch Client ID',
-    callback: 'Your Callback URL',
-    secret: 'It\'s a secret', // default: false
-    lease_seconds: 259200,    // default: 864000 (maximum value)
-    listen: {
-        port: 8080,           // default: 8443
-        host: '127.0.0.1',    // default: 0.0.0.0
-        autoStart: false      // default: true
-    }
+  client_id: 'Your Twitch Client ID',
+  callback: 'Your Callback URL',
+  access_token: 'Your access token', // default: null (ignored)
+  secret: 'It\'s a secret',          // default: false
+  lease_seconds: 259200,             // default: 864000 (maximum value)
+  listen: {
+    port: 8080,                    // default: 8443
+    host: '127.0.0.1',             // default: 0.0.0.0
+    autoStart: false               // default: true
+  }
 })
 
 // set listener for all topics

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ class TwitchWebhook extends EventEmitter {
    * will be delivered.
    * @param {string} [options.secret=false] - Secret used to sign
    * notification payloads.
+   * @param {string} [options.access_token] - Access token used to increase rate limit
    * @param {number} [options.lease_seconds=864000] - Number of seconds until
    * the subscription expires.
    * @param {boolean|Object} [options.listen] - Listen options
@@ -156,8 +157,14 @@ class TwitchWebhook extends EventEmitter {
 
     let requestOptions = {}
     requestOptions.url = this._hubUrl
-    requestOptions.headers = {
-      'Client-ID': this._options.client_id
+    if (this._options.access_token !== undefined) {
+      requestOptions.headers = {
+        'Authorization': `Bearer ${this._options.access_token}`
+      }
+    } else {
+      requestOptions.headers = {
+        'Client-ID': this._options.client_id
+      }
     }
     requestOptions.qs = {
       'hub.callback': this._options.callback,


### PR DESCRIPTION
Currently you're limited to 30 tickets a minute. You can get 800 tickets a minute by simply adding the token header.